### PR TITLE
refactor: remove debug prints and cleanup code

### DIFF
--- a/main.py
+++ b/main.py
@@ -514,7 +514,6 @@ class SoupaiPlugin(Star):
     # ✅ 生成谜题和答案
     async def generate_story_with_llm(self) -> Tuple[str, str]:
         """使用 LLM 生成海龟汤谜题"""
-        print(f"[测试输出] 开始生成故事，LLM提供商ID: {self.generate_llm_provider_id}")
 
         # 根据配置获取指定的生成 LLM 提供商
         if self.generate_llm_provider_id:
@@ -523,22 +522,17 @@ class SoupaiPlugin(Star):
                 logger.error(
                     f"未找到指定的生成 LLM 提供商: {self.generate_llm_provider_id}"
                 )
-                print(
-                    f"[测试输出] 生成故事失败：未找到指定的LLM提供商 {self.generate_llm_provider_id}"
-                )
                 return "（无法生成题面，指定的生成 LLM 提供商不存在）", "（无）"
         else:
             provider = self.context.get_using_provider()
             if provider is None:
                 logger.error("未配置 LLM 服务商")
-                print("[测试输出] 生成故事失败：未配置LLM服务商")
                 return "（无法生成题面，请先配置大语言模型）", "（无）"
 
         prompt = self._build_puzzle_prompt()
 
         try:
             logger.info("开始调用 LLM 生成谜题...")
-            print("[测试输出] 调用LLM生成谜题...")
             llm_resp: LLMResponse = await provider.text_chat(
                 prompt=prompt,
                 contexts=[],
@@ -549,7 +543,6 @@ class SoupaiPlugin(Star):
 
             text = llm_resp.completion_text.strip()
             logger.info(f"LLM 返回内容: {text}")
-            print(f"[测试输出] LLM返回内容: {text[:100]}...")
 
             # 尝试多种格式解析
             puzzle = None
@@ -615,17 +608,12 @@ class SoupaiPlugin(Star):
                     answer = answer.split("---")[0].strip()
 
                 logger.info(f"成功解析谜题: 题面='{puzzle}', 答案='{answer}'")
-                print(
-                    f"[测试输出] 成功解析谜题: 题面='{puzzle}', 答案='{answer[:50]}...'"
-                )
                 return puzzle, answer
 
             logger.error(f"LLM 返回内容格式错误: {text}")
-            print(f"[测试输出] LLM返回内容格式错误: {text[:100]}...")
             return "生成失败", "无法解析 LLM 返回的内容"
         except Exception as e:
             logger.error(f"生成谜题失败: {e}")
-            print(f"[测试输出] 生成谜题异常: {e}")
             return "生成失败", f"LLM 调用出错: {e}"
 
     def _build_puzzle_prompt(self) -> str:
@@ -854,7 +842,6 @@ class SoupaiPlugin(Star):
     # ✅ 判断提问的回答方式
     async def judge_question(self, question: str, true_answer: str) -> str:
         """使用 LLM 判断用户提问的回答方式"""
-        print(f"[测试输出] 开始判断问题: '{question[:30]}...'")
 
         # 根据配置获取指定的判断 LLM 提供商
         if self.judge_llm_provider_id:
@@ -863,14 +850,10 @@ class SoupaiPlugin(Star):
                 logger.error(
                     f"未找到指定的判断 LLM 提供商: {self.judge_llm_provider_id}"
                 )
-                print(
-                    f"[测试输出] 判断问题失败：未找到指定的LLM提供商 {self.judge_llm_provider_id}"
-                )
                 return "（未配置判断 LLM，无法判断）"
         else:
             provider = self.context.get_using_provider()
             if provider is None:
-                print("[测试输出] 判断问题失败：未配置LLM服务商")
                 return "（未配置 LLM，无法判断）"
 
         prompt = (
@@ -886,7 +869,6 @@ class SoupaiPlugin(Star):
         )
 
         try:
-            print("[测试输出] 调用LLM判断问题...")
             llm_resp: LLMResponse = await provider.text_chat(
                 prompt=prompt,
                 contexts=[],
@@ -896,13 +878,11 @@ class SoupaiPlugin(Star):
             )
 
             reply = llm_resp.completion_text.strip()
-            print(f"[测试输出] LLM判断回复: '{reply}'")
             if reply.startswith("是") or reply.startswith("否"):
                 return reply
             return "是也不是。"
         except Exception as e:
             logger.error(f"判断问题失败: {e}")
-            print(f"[测试输出] 判断问题异常: {e}")
             return "（判断失败，请重试）"
 
     # ✅ 生成方向性提示
@@ -978,17 +958,14 @@ class SoupaiPlugin(Star):
         """开始海龟汤游戏"""
         group_id = event.get_group_id()
         logger.info(f"收到开始游戏指令，群ID: {group_id}")
-        print(f"[测试输出] 收到 /汤 指令，群ID: {group_id}")
 
         if not group_id:
-            print("[测试输出] /汤 指令：非群聊环境，拒绝执行")
             yield event.plain_result("海龟汤游戏只能在群聊中进行哦~")
             return
 
         # 检查是否已有活跃游戏
         if self.game_state.is_game_active(group_id):
             logger.info(f"群 {group_id} 已有活跃游戏")
-            print(f"[测试输出] /汤 指令：群 {group_id} 已有活跃游戏")
             yield event.plain_result(
                 "当前群聊已有活跃的海龟汤游戏，请等待游戏结束或使用 /揭晓 结束当前游戏。"
             )
@@ -997,7 +974,6 @@ class SoupaiPlugin(Star):
         # 检查是否正在生成谜题
         if group_id in self.generating_games:
             logger.info(f"群 {group_id} 正在生成谜题，忽略重复请求")
-            print(f"[测试输出] /汤 指令：群 {group_id} 正在生成谜题")
             yield event.plain_result("当前有正在生成的谜题，请稍候...")
             return
 
@@ -1005,17 +981,14 @@ class SoupaiPlugin(Star):
             # 标记正在生成谜题
             self.generating_games.add(group_id)
             logger.info(f"开始为群 {group_id} 生成谜题")
-            print(f"[测试输出] /汤 指令：开始为群 {group_id} 生成谜题")
 
             # 根据策略获取谜题
             strategy = self.puzzle_source_strategy
-            print(f"[测试输出] /汤 指令：使用策略 '{strategy}' 获取谜题")
 
             # 使用统一的策略方法获取故事
             story = await self.get_story_by_strategy(strategy)
 
             if not story:
-                print("[测试输出] /汤 指令：策略执行失败，无法获取谜题")
                 yield event.plain_result("获取谜题失败，请重试")
                 self.generating_games.discard(group_id)
                 return
@@ -1024,14 +997,10 @@ class SoupaiPlugin(Star):
 
             # 检查LLM生成是否失败
             if puzzle == "（无法生成题面，请先配置大语言模型）":
-                print(f"[测试输出] /汤 指令：LLM生成失败 - {answer}")
                 yield event.plain_result(f"生成谜题失败：{answer}")
                 self.generating_games.discard(group_id)
                 return
 
-            print(
-                f"[测试输出] /汤 指令：最终获取谜题结果 - 题面: {puzzle[:20]}..., 答案: {answer[:20]}..."
-            )
 
             difficulty = self.group_difficulty.get(group_id, "普通")
             diff_conf = self.difficulty_settings.get(
@@ -1050,7 +1019,6 @@ class SoupaiPlugin(Star):
                     hint_limit=diff_conf.get("hint_limit"),
                     hint_count=0,
             ):
-                print(f"[测试输出] /汤 指令：游戏启动成功，群ID: {group_id}")
                 extra = ""
                 if diff_conf["limit"] is not None:
                     extra = f"\n模式：{difficulty}（{diff_conf['limit']} 次提问"
@@ -1072,51 +1040,36 @@ class SoupaiPlugin(Star):
                 # 启动会话控制
                 await self._start_game_session(event, group_id, answer)
             else:
-                print(f"[测试输出] /汤 指令：游戏启动失败，群ID: {group_id}")
                 yield event.plain_result("游戏启动失败，请重试")
 
             # 移除生成状态，因为故事已经准备完成
             self.generating_games.discard(group_id)
             logger.info(f"群 {group_id} 故事准备完成，移除生成状态")
-            print(f"[测试输出] /汤 指令：故事准备完成，移除生成状态，群ID: {group_id}")
 
         except Exception as e:
             logger.error(f"启动游戏失败: {e}")
-            print(f"[测试输出] /汤 指令：启动游戏异常 - {e}")
             # 发生异常时也要移除生成状态
             self.generating_games.discard(group_id)
             logger.info(f"群 {group_id} 启动游戏异常，移除生成状态")
-            print(f"[测试输出] /汤 指令：启动游戏异常，移除生成状态，群ID: {group_id}")
             yield event.plain_result(f"启动游戏时发生错误：{e}")
 
     # 🔍 揭晓指令
     @filter.command("揭晓")
     async def reveal_answer(self, event: AstrMessageEvent):
         """揭晓答案"""
-        print("[测试输出] /揭晓 指令处理器被调用！")
-        print(f"[测试输出] /揭晓 指令：完整消息: '{event.message_str}'")
         group_id = event.get_group_id()
-        print(f"[测试输出] 收到 /揭晓 指令，群ID: {group_id}")
 
         if not group_id:
-            print("[测试输出] /揭晓 指令：非群聊环境，拒绝执行")
             yield event.plain_result("海龟汤游戏只能在群聊中进行哦~")
             return
 
         # 检查是否有活跃游戏，如果有活跃游戏，说明在会话控制中，不在这里处理
         if self.game_state.is_game_active(group_id):
-            print(
-                f"[测试输出] /揭晓 指令：群 {group_id} 有活跃游戏，由会话控制处理，阻止事件传播"
-            )
             # 阻止事件继续传播，避免被会话控制系统重复处理
             await event.block()
             return
-        else:
-            print(f"[测试输出] /揭晓 指令：群 {group_id} 没有活跃游戏，独立处理器处理")
-
         game = self.game_state.get_game(group_id)
         if not game:
-            print(f"[测试输出] /揭晓 指令：群 {group_id} 没有活跃游戏")
             yield event.plain_result(
                 "当前没有活跃的海龟汤游戏，请使用 /汤 开始新游戏。"
             )
@@ -1124,7 +1077,6 @@ class SoupaiPlugin(Star):
 
         answer = game["answer"]
         puzzle = game["puzzle"]
-        print(f"[测试输出] /揭晓 指令：揭晓答案成功，群ID: {group_id}")
 
         # 发送完整的揭晓信息
         yield event.plain_result(
@@ -1134,7 +1086,6 @@ class SoupaiPlugin(Star):
         # 结束游戏
         self.game_state.end_game(group_id)
         logger.info(f"游戏已结束，群ID: {group_id}")
-        print(f"[测试输出] /揭晓 指令：游戏已结束，群ID: {group_id}")
 
     # 🎯 游戏会话控制
     async def _start_game_session(
@@ -1148,64 +1099,13 @@ class SoupaiPlugin(Star):
                     controller: SessionController, event: AstrMessageEvent
             ):
                 try:
-                    print(f"[测试输出] 会话控制：进入会话控制函数，群ID: {group_id}")
                     # 从游戏状态获取答案，确保变量可用
                     game = self.game_state.get_game(group_id)
                     if not game:
-                        print(
-                            f"[测试输出] 会话控制：无法获取游戏状态，群ID: {group_id}"
-                        )
                         return
                     current_answer = game["answer"]
                     user_input = event.message_str.strip()
                     logger.info(f"会话控制收到消息: '{user_input}'")
-                    print(f"[测试输出] 会话控制收到消息: '{user_input}'")
-                    print(
-                        f"[测试输出] 会话控制：原始消息长度: {len(event.message_str)}"
-                    )
-                    print(f"[测试输出] 会话控制：user_input长度: {len(user_input)}")
-                    print(
-                        f"[测试输出] 会话控制：user_input的字节表示: {user_input.encode('utf-8')}"
-                    )
-                    print(f"[测试输出] 会话控制：原始消息: '{event.message_str}'")
-                    print(
-                        f"[测试输出] 会话控制：user_input in ('/查看', '查看'): {user_input in ('/查看', '查看')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input == '/查看': {user_input == '/查看'}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input == '查看': {user_input == '查看'}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：'查看' in user_input: {'查看' in user_input}"
-                    )
-                    print(f"[测试输出] 会话控制：消息类型: {type(event).__name__}")
-                    print(f"[测试输出] 会话控制：消息来源: {event.unified_msg_origin}")
-                    print(
-                        f"[测试输出] 会话控制：消息ID: {getattr(event, 'message_id', 'N/A')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：时间戳: {getattr(event, 'time', 'N/A')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input.startswith('/'): {user_input.startswith('/')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input == '揭晓': {user_input == '揭晓'}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input.startswith('/验证'): {user_input.startswith('/验证')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input.startswith('揭晓'): {user_input.startswith('揭晓')}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input 的每个字符: {[ord(c) for c in user_input[:10]]}"
-                    )
-                    print(
-                        f"[测试输出] 会话控制：user_input 是否以'验证'开头: {user_input.startswith('验证')}"
-                    )
 
                     # 允许在会话中使用 /汤状态 和 /强制结束 指令
                     if user_input in ("/汤状态", "汤状态"):
@@ -1220,9 +1120,6 @@ class SoupaiPlugin(Star):
 
                     normalized_input = user_input.lstrip("/").strip()
                     if normalized_input == "查看":
-                        print(
-                            f"[测试输出] 会话控制：检测到查看指令，user_input='{user_input}'"
-                        )
                         await self._handle_view_history_in_session(event, group_id)
                         controller.keep(timeout=self.game_timeout, reset_timeout=True)
                         return
@@ -1234,22 +1131,17 @@ class SoupaiPlugin(Star):
                         return
                     # 特殊处理 /验证 指令
                     if user_input.startswith("/验证"):
-                        print(
-                            f"[测试输出] 会话控制：检测到 /验证 指令，手动调用验证函数，消息ID: {getattr(event, 'message_id', 'N/A')}"
-                        )
                         import re
 
                         match = re.match(r"^/验证\s*(.+)$", user_input)
                         if match:
                             user_guess = match.group(1).strip()
-                            print(f"[测试输出] 会话控制：提取验证内容: '{user_guess}'")
                             # 手动调用验证函数
                             await self._handle_verification_in_session(
                                 event, user_guess, current_answer
                             )
                             # 检查游戏是否已结束（用户可能猜中了）
                             if not self.game_state.is_game_active(group_id):
-                                print("[测试输出] 会话控制：游戏已结束，停止会话")
                                 controller.stop()
                                 return
                         else:
@@ -1260,22 +1152,17 @@ class SoupaiPlugin(Star):
                             )
                         return
                     elif user_input.startswith("验证"):
-                        print(
-                            "[测试输出] 会话控制：检测到 验证 指令（无斜杠），手动调用验证函数"
-                        )
                         import re
 
                         match = re.match(r"^验证\s*(.+)$", user_input)
                         if match:
                             user_guess = match.group(1).strip()
-                            print(f"[测试输出] 会话控制：提取验证内容: '{user_guess}'")
                             # 手动调用验证函数
                             await self._handle_verification_in_session(
                                 event, user_guess, current_answer
                             )
                             # 检查游戏是否已结束（用户可能猜中了）
                             if not self.game_state.is_game_active(group_id):
-                                print("[测试输出] 会话控制：游戏已结束，停止会话")
                                 controller.stop()
                                 return
                         else:
@@ -1285,12 +1172,8 @@ class SoupaiPlugin(Star):
                                 )
                             )
                         return
-                    else:
-                        print("[测试输出] 会话控制：不是 /验证 指令")
-
                     # 特殊处理 /揭晓 指令
                     if user_input == "揭晓":
-                        print("[测试输出] 会话控制：检测到 /揭晓 指令，结束会话")
                         # 获取游戏信息并发送答案
                         game = self.game_state.get_game(group_id)
                         if game:
@@ -1302,31 +1185,15 @@ class SoupaiPlugin(Star):
                                 )
                             )
                             self.game_state.end_game(group_id)
-                            print(
-                                f"[测试输出] 会话控制：已揭晓答案并结束游戏，群ID: {group_id}"
-                            )
                         controller.stop()
                         return
-                    else:
-                        print("[测试输出] 会话控制：不是 /揭晓 指令")
-
                     # Step 1: 检查是否是 /开头的命令，如果是则忽略，让指令处理器处理
                     if user_input.startswith("/"):
-                        print(
-                            f"[测试输出] 会话控制：检测到指令 '{user_input}'，忽略让指令处理器处理"
-                        )
                         # 不处理指令，让事件继续传播到指令处理器
                         return
-                    else:
-                        print("[测试输出] 会话控制：不是其他指令")
-
                     # Step 2: 检查是否 @了 bot，只有@bot的消息才触发问答判断
                     if not self._is_at_bot(event):
-                        print("[测试输出] 会话控制：用户未@bot，跳过是否判断")
                         return
-                    else:
-                        print("[测试输出] 会话控制：消息已@bot，继续处理问答")
-
                     # Step 3: 是@bot的自然语言提问，触发 LLM 判断
                     game = self.game_state.get_game(group_id)
                     question_limit = game.get("question_limit") if game else None
@@ -1340,20 +1207,14 @@ class SoupaiPlugin(Star):
                         )
                         return
 
-                    print(
-                        f"[测试输出] 会话控制：处理@bot的游戏问答消息: '{user_input}'"
-                    )
 
                     # 处理游戏问答消息
                     command_part = user_input.strip()  # 直接使用 plain_text
                     logger.info(f"处理游戏问答消息: '{command_part}'")
-                    print(f"[测试输出] 会话控制：处理游戏问答消息: '{command_part}'")
 
                     # 使用 LLM 判断回答（是否问答）
                     logger.info(f"使用 LLM 判断游戏问答: '{command_part}'")
-                    print("[测试输出] 会话控制：开始LLM判断")
                     reply = await self.judge_question(command_part, current_answer)
-                    print(f"[测试输出] 会话控制：LLM回复: '{reply}'")
 
                     # 记录提问和回答
                     if game is not None:
@@ -1381,21 +1242,17 @@ class SoupaiPlugin(Star):
 
                     # 重置超时时间
                     controller.keep(timeout=self.game_timeout, reset_timeout=True)
-                    print("[测试输出] 会话控制：重置超时时间")
 
                 except Exception as e:
                     logger.error(f"会话控制内部错误: {e}")
-                    print(f"[测试输出] 会话控制内部错误: {e}")
                     await event.send(event.plain_result(f"游戏处理过程中发生错误：{e}"))
                     # 如果发生错误，结束游戏
                     self.game_state.end_game(group_id)
                     controller.stop()
 
             try:
-                print(f"[测试输出] 启动游戏会话，群ID: {group_id}")
                 await game_session_waiter(event, session_filter=GroupSessionFilter())
             except TimeoutError:
-                print(f"[测试输出] 游戏会话超时，群ID: {group_id}")
                 game = self.game_state.get_game(group_id)
                 if game:
                     await event.send(
@@ -1406,12 +1263,10 @@ class SoupaiPlugin(Star):
                     self.game_state.end_game(group_id)
             except Exception as e:
                 logger.error(f"游戏会话错误: {e}")
-                print(f"[测试输出] 游戏会话异常: {e}")
                 await event.send(event.plain_result(f"游戏过程中发生错误：{e}"))
                 self.game_state.end_game(group_id)
         except Exception as e:
             logger.error(f"启动游戏会话失败: {e}")
-            print(f"[测试输出] 启动游戏会话失败: {e}")
             await event.send(event.plain_result(f"启动游戏会话失败：{e}"))
 
     def _is_at_bot(self, event: AstrMessageEvent) -> bool:
@@ -1431,98 +1286,61 @@ class SoupaiPlugin(Star):
 
         if strategy == "network_first":
             # 策略1：优先网络题库 -> 本地存储库 -> LLM现场生成
-            print("[测试输出] 策略执行：使用 network_first 策略")
 
             # 1. 检查网络题库
             story = self.online_story_storage.get_story()
             if story:
-                print(
-                    f"[测试输出] 策略执行：从网络题库获取故事成功，剩余: {self.online_story_storage.get_storage_info()['total']}"
-                )
                 return story
 
-            print("[测试输出] 策略执行：网络题库为空，检查本地存储库")
             # 2. 检查本地存储库
             story = self.local_story_storage.get_story()
             if story:
-                print(
-                    f"[测试输出] 策略执行：从本地存储库获取故事成功，剩余: {self.local_story_storage.get_storage_info()['total']}"
-                )
                 return story
 
-            print("[测试输出] 策略执行：本地存储库也为空，需要LLM现场生成")
             # 3. LLM现场生成
             return await self.generate_story_with_llm()
 
         elif strategy == "ai_first":
             # 策略2：优先本地存储库 -> 网络题库 -> LLM现场生成
-            print("[测试输出] 策略执行：使用 ai_first 策略")
 
             # 1. 检查本地存储库
             story = self.local_story_storage.get_story()
             if story:
-                print(
-                    f"[测试输出] 策略执行：从本地存储库获取故事成功，剩余: {self.local_story_storage.get_storage_info()['total']}"
-                )
                 return story
 
-            print("[测试输出] 策略执行：本地存储库为空，检查网络题库")
             # 2. 检查网络题库
             story = self.online_story_storage.get_story()
             if story:
-                print(
-                    f"[测试输出] 策略执行：从网络题库获取故事成功，剩余: {self.online_story_storage.get_storage_info()['total']}"
-                )
                 return story
 
-            print("[测试输出] 策略执行：网络题库也为空，需要LLM现场生成")
             # 3. LLM现场生成
             return await self.generate_story_with_llm()
 
         elif strategy == "random":
             # 策略3：随机选择网络题库或本地存储库，失败时使用LLM现场生成
-            print("[测试输出] 策略执行：使用 random 策略")
 
             # 随机决定这次从网络题库还是本地存储库获取
             if random.choice(["network", "storage"]) == "network":
-                print("[测试输出] 策略执行：随机策略选择网络题库")
                 # 参考策略1的网络题库逻辑
                 story = self.online_story_storage.get_story()
                 if story:
-                    print(
-                        f"[测试输出] 策略执行：从网络题库获取故事成功，剩余: {self.online_story_storage.get_storage_info()['total']}"
-                    )
                     return story
 
-                print("[测试输出] 策略执行：网络题库为空，检查本地存储库")
                 story = self.local_story_storage.get_story()
                 if story:
-                    print(
-                        f"[测试输出] 策略执行：从本地存储库获取故事成功，剩余: {self.local_story_storage.get_storage_info()['total']}"
-                    )
                     return story
 
-                print("[测试输出] 策略执行：本地存储库也为空，需要LLM现场生成")
                 return await self.generate_story_with_llm()
             else:
-                print("[测试输出] 策略执行：随机策略选择本地存储库")
                 # 参考策略2的本地存储库逻辑
                 story = self.local_story_storage.get_story()
                 if story:
-                    print(
-                        f"[测试输出] 策略执行：从本地存储库获取故事成功，剩余: {self.local_story_storage.get_storage_info()['total']}"
-                    )
                     return story
 
-                print("[测试输出] 策略执行：本地存储库为空，检查网络题库")
                 story = self.online_story_storage.get_story()
                 if story:
-                    print(
-                        f"[测试输出] 策略执行：从网络题库获取故事成功，剩余: {self.online_story_storage.get_storage_info()['total']}"
-                    )
                     return story
 
-                print("[测试输出] 策略执行：网络题库也为空，需要LLM现场生成")
                 return await self.generate_story_with_llm()
 
         return None
@@ -1532,11 +1350,9 @@ class SoupaiPlugin(Star):
     ):
         """在会话控制中处理游戏状态查询逻辑"""
         try:
-            print(f"[测试输出] 会话游戏状态：开始查询游戏状态，群ID: {group_id}")
 
             if self.game_state.is_game_active(group_id):
                 game = self.game_state.get_game(group_id)
-                print(f"[测试输出] 会话游戏状态：群 {group_id} 有活跃游戏")
                 difficulty = game.get("difficulty", "普通")
                 question_count = game.get("question_count", 0)
                 question_limit = game.get("question_limit")
@@ -1552,7 +1368,6 @@ class SoupaiPlugin(Star):
                     )
                 )
             else:
-                print(f"[测试输出] 会话游戏状态：群 {group_id} 没有活跃游戏")
                 await event.send(
                     event.plain_result(
                         "🎮 当前没有活跃的海龟汤游戏\n💡 使用 /汤 开始新游戏"
@@ -1561,7 +1376,6 @@ class SoupaiPlugin(Star):
 
         except Exception as e:
             logger.error(f"会话游戏状态查询失败: {e}")
-            print(f"[测试输出] 会话游戏状态查询异常: {e}")
             await event.send(event.plain_result(f"查询游戏状态时发生错误：{e}"))
 
     async def _handle_force_end_in_session(
@@ -1569,18 +1383,14 @@ class SoupaiPlugin(Star):
     ):
         """在会话控制中处理强制结束游戏逻辑"""
         try:
-            print(f"[测试输出] 会话强制结束：开始强制结束游戏，群ID: {group_id}")
 
             if self.game_state.end_game(group_id):
-                print(f"[测试输出] 会话强制结束：成功结束游戏，群ID: {group_id}")
                 await event.send(event.plain_result("✅ 已强制结束当前海龟汤游戏"))
             else:
-                print(f"[测试输出] 会话强制结束：没有活跃游戏，群ID: {group_id}")
                 await event.send(event.plain_result("❌ 当前没有活跃的游戏需要结束"))
 
         except Exception as e:
             logger.error(f"会话强制结束失败: {e}")
-            print(f"[测试输出] 会话强制结束异常: {e}")
             await event.send(event.plain_result(f"强制结束游戏时发生错误：{e}"))
 
     async def _handle_view_history_in_session(
@@ -1588,29 +1398,18 @@ class SoupaiPlugin(Star):
     ):
         """在会话控制中处理查看历史记录逻辑"""
         try:
-            print(f"[测试输出] 会话查看历史：开始查看历史记录，群ID: {group_id}")
-            print(f"[测试输出] 会话查看历史：event.message_str='{event.message_str}'")
-            print(
-                f"[测试输出] 会话查看历史：event.message_str.strip()='{event.message_str.strip()}'"
-            )
 
             # 先发送一个简单的测试消息
-            print("[测试输出] 会话查看历史：发送测试消息")
             await event.send(event.plain_result("测试：正在查看历史记录..."))
-            print("[测试输出] 会话查看历史：测试消息已发送")
 
             game = self.game_state.get_game(group_id)
             if not game:
-                print("[测试输出] 会话查看历史：无法获取游戏状态")
                 await event.send(event.plain_result("无法获取游戏状态"))
                 return
 
             history = game.get("qa_history", [])
-            print(f"[测试输出] 会话查看历史：历史记录数量: {len(history)}")
-            print(f"[测试输出] 会话查看历史：历史记录内容: {history}")
 
             if not history:
-                print("[测试输出] 会话查看历史：没有历史记录")
                 await event.send(event.plain_result("目前还没有人提问哦~"))
                 return
 
@@ -1619,14 +1418,10 @@ class SoupaiPlugin(Star):
                 lines.append(f"{idx}. 问：{item['question']}\n   答：{item['answer']}")
 
             response = "\n".join(lines)
-            print(f"[测试输出] 会话查看历史：发送历史记录，长度: {len(response)}")
-            print(f"[测试输出] 会话查看历史：响应内容: {response}")
             await event.send(event.plain_result(response))
-            print("[测试输出] 会话查看历史：消息已发送")
 
         except Exception as e:
             logger.error(f"会话查看历史失败: {e}")
-            print(f"[测试输出] 会话查看历史异常: {e}")
             await event.send(event.plain_result(f"查看历史记录时发生错误：{e}"))
 
     async def _build_hint_result(
@@ -1663,7 +1458,6 @@ class SoupaiPlugin(Star):
     ):
         """在会话控制中处理验证逻辑"""
         try:
-            print(f"[测试输出] 会话验证：开始验证推理: '{user_guess}'")
 
             # 验证用户推理
             result = await self.verify_user_guess(user_guess, answer)
@@ -1676,16 +1470,12 @@ class SoupaiPlugin(Star):
                 else ["完全还原", "核心推理正确"]
             )
             is_correct = result.level in accept_levels
-            print(
-                f"[测试输出] 会话验证：验证结果 - 等级:{result.level}, 是否猜中:{is_correct}"
-            )
 
             # 返回验证结果
             response = f"等级：{result.level}\n评价：{result.comment}"
             await event.send(event.plain_result(response))
 
             if is_correct:
-                print("[测试输出] 会话验证：用户猜中，结束游戏")
                 await event.send(
                     event.plain_result(
                         f"🎉 恭喜！你猜中了！\n\n📖 完整故事：{answer}\n\n游戏结束！"
@@ -1718,26 +1508,20 @@ class SoupaiPlugin(Star):
 
         except Exception as e:
             logger.error(f"会话验证失败: {e}")
-            print(f"[测试输出] 会话验证异常: {e}")
             await event.send(event.plain_result(f"验证过程中发生错误：{e}"))
 
     # 📊 游戏状态查询
     @filter.command("汤状态")
     async def check_game_status(self, event: AstrMessageEvent):
         """查看当前游戏状态"""
-        print("[测试输出] /汤状态 指令处理器被调用！")
-        print(f"[测试输出] /汤状态 指令：完整消息: '{event.message_str}'")
         group_id = event.get_group_id()
-        print(f"[测试输出] 收到 /汤状态 指令，群ID: {group_id}")
 
         if not group_id:
-            print("[测试输出] /汤状态 指令：非群聊环境，拒绝执行")
             yield event.plain_result("此功能只能在群聊中使用")
             return
 
         if self.game_state.is_game_active(group_id):
             game = self.game_state.get_game(group_id)
-            print(f"[测试输出] /汤状态 指令：群 {group_id} 有活跃游戏")
             difficulty = game.get("difficulty", "普通")
             question_count = game.get("question_count", 0)
             question_limit = game.get("question_limit")
@@ -1751,7 +1535,6 @@ class SoupaiPlugin(Star):
                 f"🎮 当前有活跃的海龟汤游戏\n📖 题面：{game['puzzle']}\n🎯 难度：{difficulty}\n❓ 提问：{question_info}\n💡 提示：{hint_info}"
             )
         else:
-            print(f"[测试输出] /汤状态 指令：群 {group_id} 没有活跃游戏")
             yield event.plain_result(
                 "🎮 当前没有活跃的海龟汤游戏\n💡 使用 /汤 开始新游戏"
             )
@@ -1759,33 +1542,22 @@ class SoupaiPlugin(Star):
     @filter.command("查看")
     async def view_question_history(self, event: AstrMessageEvent):
         """查看当前已提问的问题及回答"""
-        print("[测试输出] 独立/查看指令处理器被调用！")
-        print(f"[测试输出] 独立/查看指令：完整消息: '{event.message_str}'")
         group_id = event.get_group_id()
-        print(f"[测试输出] 独立/查看指令：群ID: {group_id}")
-        print(
-            f"[测试输出] 独立/查看指令：是否有活跃游戏: {self.game_state.is_game_active(group_id)}"
-        )
 
         if not group_id:
-            print("[测试输出] 独立/查看指令：非群聊环境")
             yield event.plain_result("此功能只能在群聊中使用")
             return
         if not self.game_state.is_game_active(group_id):
-            print("[测试输出] 独立/查看指令：没有活跃游戏")
             yield event.plain_result("当前没有活跃的海龟汤游戏")
             return
         game = self.game_state.get_game(group_id)
         history = game.get("qa_history", []) if game else []
-        print(f"[测试输出] 独立/查看指令：历史记录数量: {len(history)}")
         if not history:
-            print("[测试输出] 独立/查看指令：没有历史记录")
             yield event.plain_result("目前还没有人提问哦~")
             return
         lines = ["📋 提问记录："]
         for idx, item in enumerate(history, 1):
             lines.append(f"{idx}. 问：{item['question']}\n   答：{item['answer']}")
-        print("[测试输出] 独立/查看指令：发送历史记录")
         yield event.plain_result("\n".join(lines))
 
     # 🆘 强制结束游戏（管理员功能）
@@ -1794,18 +1566,14 @@ class SoupaiPlugin(Star):
     async def force_end_game(self, event: AstrMessageEvent):
         """强制结束当前游戏（仅管理员）"""
         group_id = event.get_group_id()
-        print(f"[测试输出] 收到 /强制结束 指令，群ID: {group_id}")
 
         if not group_id:
-            print("[测试输出] /强制结束 指令：非群聊环境，拒绝执行")
             yield event.plain_result("此功能只能在群聊中使用")
             return
 
         if self.game_state.end_game(group_id):
-            print(f"[测试输出] /强制结束 指令：成功结束游戏，群ID: {group_id}")
             yield event.plain_result("✅ 已强制结束当前海龟汤游戏")
         else:
-            print(f"[测试输出] /强制结束 指令：没有活跃游戏，群ID: {group_id}")
             yield event.plain_result("❌ 当前没有活跃的游戏需要结束")
 
     # 📚 备用故事管理指令
@@ -1813,10 +1581,8 @@ class SoupaiPlugin(Star):
     @filter.command("备用开始")
     async def start_backup_generation(self, event: AstrMessageEvent):
         """开始生成备用故事（仅管理员）"""
-        print("[测试输出] 收到 /备用开始 指令")
 
         if self.auto_generating:
-            print("[测试输出] /备用开始 指令：已在运行中")
             yield event.plain_result("⚠️ 备用故事生成已在运行中")
             return
 
@@ -1824,14 +1590,10 @@ class SoupaiPlugin(Star):
         self._ensure_story_storages()
         storage_info = self.local_story_storage.get_storage_info()
         if storage_info["available"] <= 0:
-            print("[测试输出] /备用开始 指令：存储库已满")
             yield event.plain_result("⚠️ 存储库已满，无法生成更多故事")
             return
 
         self.auto_generating = True
-        print(
-            f"[测试输出] /备用开始 指令：开始生成，存储库状态: {storage_info['total']}/{storage_info['max_size']}"
-        )
         asyncio.create_task(self._auto_generate_loop())
         yield event.plain_result(
             f"✅ 开始生成备用故事，存储库状态: {storage_info['total']}/{storage_info['max_size']}"
@@ -1867,7 +1629,6 @@ class SoupaiPlugin(Star):
                     and not user_input.startswith("/查看")
                     and not user_input.startswith("/提示")
             ):
-                print(f"[测试输出] 全局拦截器：拦截指令 '{user_input}'")
                 yield event.plain_result(
                     "⚠️ 系统正在生成备用故事，请稍后再试或使用 /备用结束 停止生成"
                 )
@@ -1876,29 +1637,22 @@ class SoupaiPlugin(Star):
     @filter.command("备用结束")
     async def stop_backup_generation(self, event: AstrMessageEvent):
         """停止生成备用故事（仅管理员）"""
-        print("[测试输出] 收到 /备用结束 指令")
 
         if not self.auto_generating:
-            print("[测试输出] /备用结束 指令：未在运行")
             yield event.plain_result("⚠️ 备用故事生成未在运行")
             return
 
         self.auto_generating = False
-        print("[测试输出] /备用结束 指令：已停止生成")
         yield event.plain_result("✅ 已停止生成备用故事，正在完成当前生成...")
 
     @filter.command("备用状态")
     async def check_backup_status(self, event: AstrMessageEvent):
         """查看备用故事状态"""
-        print("[测试输出] 收到 /备用状态 指令")
         self._ensure_story_storages()
         storage_info = self.local_story_storage.get_storage_info()
         online_info = self.online_story_storage.get_storage_info()
         status = "🟢 运行中" if self.auto_generating else "🔴 已停止"
 
-        print(
-            f"[测试输出] /备用状态 指令：生成状态={status}, 本地存储库={storage_info['total']}/{storage_info['max_size']}"
-        )
 
         # 检查存储库是否已满
         storage_full_warning = ""
@@ -1922,7 +1676,6 @@ class SoupaiPlugin(Star):
     @filter.command("重置题库")
     async def reset_story_storage(self, event: AstrMessageEvent):
         """重置题库使用记录（仅管理员）"""
-        print("[测试输出] 收到 /重置题库 指令")
 
         self._ensure_story_storages()
 
@@ -1934,7 +1687,6 @@ class SoupaiPlugin(Star):
         self.local_story_storage.reset_usage()
         local_info = self.local_story_storage.get_storage_info()
 
-        print("[测试输出] /重置题库 指令：已重置所有题库使用记录")
 
         message = (
             f"✅ 题库使用记录已重置！\n"
@@ -1949,7 +1701,6 @@ class SoupaiPlugin(Star):
     @filter.command("题库详情")
     async def show_storage_details(self, event: AstrMessageEvent):
         """查看题库详细使用记录（仅管理员）"""
-        print("[测试输出] 收到 /题库详情 指令")
 
         # 确保题库已初始化
         self._ensure_story_storages()
@@ -1962,9 +1713,6 @@ class SoupaiPlugin(Star):
         local_info = self.local_story_storage.get_storage_info()
         local_usage = self.local_story_storage.get_usage_info()
 
-        print(
-            f"[测试输出] /题库详情 指令：网络题库已用索引={online_usage['used_indexes']}, 本地存储库已用索引={local_usage['used_indexes']}"
-        )
 
         # 安全计算使用率，避免除零错误
         online_usage_rate = (
@@ -2007,48 +1755,30 @@ class SoupaiPlugin(Star):
     @filter.command("验证")
     async def verify_user_guess_command(self, event: AstrMessageEvent, user_guess: str):
         """验证用户推理（仅在非游戏会话时处理）"""
-        print("[测试输出] /验证 指令处理器被调用！")
-        print(f"[测试输出] /验证 指令：完整消息: '{event.message_str}'")
-        print(f"[测试输出] /验证 指令：消息ID: {getattr(event, 'message_id', 'N/A')}")
         group_id = event.get_group_id()
-        print(
-            f"[测试输出] 收到 /验证 指令，群ID: {group_id}, 推理内容: {user_guess[:30]}..."
-        )
 
         if not group_id:
-            print("[测试输出] /验证 指令：非群聊环境，拒绝执行")
             yield event.plain_result("验证功能只能在群聊中使用")
             return
 
         # 检查是否有活跃游戏，如果有活跃游戏，说明在会话控制中，不在这里处理
         if self.game_state.is_game_active(group_id):
-            print(
-                f"[测试输出] /验证 指令：群 {group_id} 有活跃游戏，由会话控制处理，阻止事件传播"
-            )
             # 阻止事件继续传播，避免被会话控制系统重复处理
             await event.block()
             return
-        else:
-            print(f"[测试输出] /验证 指令：群 {group_id} 没有活跃游戏，独立处理器处理")
-
         # 只有在没有活跃游戏时才在这里处理（用于游戏外的验证）
-        print(f"[测试输出] /验证 指令：群 {group_id} 没有活跃游戏，在此处理")
         yield event.plain_result("当前没有活跃的海龟汤游戏，请使用 /汤 开始新游戏")
 
     # ⚙️ 查看当前配置
     @filter.command("汤配置")
     async def show_config(self, event: AstrMessageEvent):
         """查看当前插件配置"""
-        print("[测试输出] 收到 /汤配置 指令")
 
         # 确保题库已初始化
         self._ensure_story_storages()
 
         local_info = self.local_story_storage.get_storage_info()
         online_info = self.online_story_storage.get_storage_info()
-        print(
-            f"[测试输出] /汤配置 指令：本地存储库状态={local_info['total']}/{local_info['max_size']}, 网络题库状态={online_info['total']}"
-        )
 
         # 获取策略的中文描述
         strategy_names = {


### PR DESCRIPTION
## Summary
- remove leftover debug print statements and test output traces
- streamline game logic to rely on structured logging and improve robustness

## Testing
- `ruff check main.py --fix`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891834f7c808330a5b7090afef0c74c